### PR TITLE
workaround external bug of added special characters

### DIFF
--- a/flexi_config/__init__.py
+++ b/flexi_config/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 try:
     from .config import Config
 except ImportError:


### PR DESCRIPTION
Sometimes (especially when running on Docker?) yaml files get special characters such as \x00 added. This works around that bug by removing them.